### PR TITLE
[Spot-35][ML] Remove csvs files as storage layer

### DIFF
--- a/spot-ml/ml_ops.sh
+++ b/spot-ml/ml_ops.sh
@@ -53,14 +53,9 @@ else
     USER_DOMAIN_CMD=''
 fi
 
-FEEDBACK_PATH=${LPATH}/${DSOURCE}_scores.csv
+FEEDBACK_PATH=${HPATH}/ml_feedback.csv
 
 HDFS_SCORED_CONNECTS=${HPATH}/scores
-
-LDA_OUTPUT_DIR=${DSOURCE}/${FDATE}
-
-mkdir -p ${LPATH}
-rm -f ${LPATH}/*.{dat,beta,gamma,other,pkl} # protect the flow_scores.csv file
 
 hdfs dfs -rm -R -f ${HDFS_SCORED_CONNECTS}
 

--- a/spot-ml/ml_ops.sh
+++ b/spot-ml/ml_ops.sh
@@ -53,7 +53,7 @@ else
     USER_DOMAIN_CMD=''
 fi
 
-FEEDBACK_PATH=${HPATH}/ml_feedback.csv
+FEEDBACK_PATH=${HPATH}/feedback/ml_feedback.csv
 
 HDFS_SCORED_CONNECTS=${HPATH}/scores
 

--- a/spot-ml/ml_test.sh
+++ b/spot-ml/ml_test.sh
@@ -14,16 +14,12 @@ source /etc/spot.conf
 TOL=1.1
 MAXRESULTS=20
 
-LPATH=${LUSER}/ml/${DSOURCE}/test
 HPATH=${HUSER}/${DSOURCE}/test/scored_results
 # prepare parameters pipeline stages
 
-FEEDBACK_PATH=${LPATH}/${DSOURCE}_scores.csv
+FEEDBACK_PATH=${HPATH}/feedback/ml_feedback.csv
 
 HDFS_SCORED_CONNECTS=${HPATH}/scores
-
-mkdir -p ${LPATH}
-rm -f ${LPATH}/*.{dat,beta,gamma,other,pkl} # protect the flow_scores.csv file
 
 hdfs dfs -rm -R -f ${HDFS_SCORED_CONNECTS}
 

--- a/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSFeedback.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/dns/model/DNSFeedback.scala
@@ -4,8 +4,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spot.dns.model.DNSSuspiciousConnectsModel.{ModelSchema, modelColumns}
-
-import scala.io.Source
+import org.apache.spot.utilities.data.InputOutputDataHandler.getFeedbackRDD
 
 /**
   * Routines for ingesting the feedback file provided by the operational analytics layer.
@@ -15,10 +14,10 @@ object DNSFeedback {
 
   /**
     * Load the feedback file for DNS data.
- *
-    * @param sc Spark context.
-    * @param sqlContext Spark SQL context.
-    * @param feedbackFile Local machine path to the DNS feedback file.
+    *
+    * @param sc                Spark context.
+    * @param sqlContext        Spark SQL context.
+    * @param feedbackFile      Local machine path to the DNS feedback file.
     * @param duplicationFactor Number of words to create per flagged feedback entry.
     * @return DataFrame of the feedback events.
     */
@@ -28,14 +27,9 @@ object DNSFeedback {
                      duplicationFactor: Int): DataFrame = {
 
 
-    if (new java.io.File(feedbackFile).exists) {
+    val feedback: RDD[String] = getFeedbackRDD(sc, feedbackFile)
 
-      /*
-      feedback file is a tab-separated file with a single header line.
-      */
-
-      val lines = Source.fromFile(feedbackFile).getLines().toArray.drop(1)
-      val feedback: RDD[String] = sc.parallelize(lines)
+    if (!feedback.isEmpty()) {
 
       /*
       The columns and their entries are as follows:
@@ -79,7 +73,7 @@ object DNSFeedback {
           row(DnsQryTypeIndex).toInt,
           row(DnsQryRcodeIndex).toInt)))
         .flatMap(row => List.fill(duplicationFactor)(row)), ModelSchema)
-        .select(modelColumns:_*)
+        .select(modelColumns: _*)
     } else {
       sqlContext.createDataFrame(sc.emptyRDD[Row], ModelSchema)
     }

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowFeedback.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowFeedback.scala
@@ -53,9 +53,6 @@ object FlowFeedback {
       val DestinationPortIndex = 5
       val IpktIndex = 6
       val IbytIndex = 7
-      val HourIndex = 20
-      val MinuteIndex = 21
-      val SecondIndex = 22
 
       sqlContext.createDataFrame(feedback.map(_.split("\t"))
         .filter(row => row(ScoreIndex).trim.toInt == 3)
@@ -65,8 +62,8 @@ object FlowFeedback {
           row(TimeStartIndex).split(" ")(1).split(":")(2).trim.toInt, // second
           row(SourceIpIndex),
           row(DestinationIpIndex),
-          row(SourcePortIndex),
-          row(DestinationPortIndex),
+          row(SourcePortIndex).trim.toInt,
+          row(DestinationPortIndex).trim.toInt,
           row(IpktIndex).trim.toLong,
           row(IbytIndex).trim.toLong)))
         .flatMap(row => List.fill(duplicationFactor)(row)), ModelSchema)

--- a/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowFeedback.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/netflow/model/FlowFeedback.scala
@@ -4,7 +4,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spot.netflow.model.FlowSuspiciousConnectsModel._
-import scala.io.Source
+import org.apache.spot.utilities.data.InputOutputDataHandler.getFeedbackRDD
 
 /**
   * Routines for ingesting the feedback file provided by the operational analytics layer.
@@ -27,27 +27,20 @@ object FlowFeedback {
                      feedbackFile: String,
                      duplicationFactor: Int): DataFrame = {
 
+    val feedback: RDD[String] = getFeedbackRDD(sc, feedbackFile)
 
-    if (new java.io.File(feedbackFile).exists) {
-
+    if (!feedback.isEmpty()) {
       /*
-      feedback file is a tab-separated file with a single header line.
-      */
-
-      val lines = Source.fromFile(feedbackFile).getLines().toArray.drop(1)
-      val feedback: RDD[String] = sc.parallelize(lines)
-
-      /*
-         flow_scores.csv - feedback file structure
-         0	sev
-         1	tstart
-         2	srcIP
-         3	dstIP
-         4	sport
-         5	dport
-         6	ipkt
-         7	ibyt
-        */
+           flow_scores.csv - feedback file structure
+           0	sev
+           1	tstart
+           2	srcIP
+           3	dstIP
+           4	sport
+           5	dport
+           6	ipkt
+           7	ibyt
+          */
 
       // Given the structure pull out indexes we need for a new DataFrame creation
       // containing the columns for word creation only.

--- a/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyFeedback.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/proxy/ProxyFeedback.scala
@@ -3,20 +3,19 @@ package org.apache.spot.proxy
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{StructType, StructField, StringType}
-import scala.io.Source
-
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spot.proxy.ProxySchema._
+import org.apache.spot.utilities.data.InputOutputDataHandler.getFeedbackRDD
 
 
 object ProxyFeedback {
 
   /**
     * Load the feedback file for proxy data.
- *
-    * @param sc Spark context.
-    * @param sqlContext Spark SQL context.
-    * @param feedbackFile Local machine path to the proxy feedback file.
+    *
+    * @param sc                Spark context.
+    * @param sqlContext        Spark SQL context.
+    * @param feedbackFile      Local machine path to the proxy feedback file.
     * @param duplicationFactor Number of words to create per flagged feedback entry.
     * @return DataFrame of the feedback events.
     */
@@ -27,17 +26,19 @@ object ProxyFeedback {
 
 
     val feedbackSchema = StructType(
-      List(StructField(Date, StringType, nullable= true),
-        StructField(Time, StringType, nullable= true),
-        StructField(ClientIP, StringType, nullable= true),
-        StructField(Host, StringType, nullable= true),
-        StructField(ReqMethod, StringType, nullable= true),
-        StructField(UserAgent, StringType, nullable= true),
-        StructField(ResponseContentType, StringType, nullable= true),
-        StructField(RespCode, StringType, nullable= true),
-        StructField(FullURI, StringType, nullable= true)))
+      List(StructField(Date, StringType, nullable = true),
+        StructField(Time, StringType, nullable = true),
+        StructField(ClientIP, StringType, nullable = true),
+        StructField(Host, StringType, nullable = true),
+        StructField(ReqMethod, StringType, nullable = true),
+        StructField(UserAgent, StringType, nullable = true),
+        StructField(ResponseContentType, StringType, nullable = true),
+        StructField(RespCode, StringType, nullable = true),
+        StructField(FullURI, StringType, nullable = true)))
 
-    if (new java.io.File(feedbackFile).exists) {
+    val feedback: RDD[String] = getFeedbackRDD(sc, feedbackFile)
+
+    if (!feedback.isEmpty()) {
 
       val dateIndex = 0
       val timeIndex = 1
@@ -50,9 +51,6 @@ object ProxyFeedback {
       val fullURIIndex = 18
 
       val fullURISeverityIndex = 22
-
-      val lines = Source.fromFile(feedbackFile).getLines().toArray.drop(1)
-      val feedback: RDD[String] = sc.parallelize(lines)
 
       sqlContext.createDataFrame(feedback.map(_.split("\t"))
         .filter(row => row(fullURISeverityIndex).trim.toInt == 3)

--- a/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
+++ b/spot-ml/src/main/scala/org/apache/spot/utilities/data/InputOutputDataHandler.scala
@@ -1,10 +1,10 @@
 package org.apache.spot.utilities.data
 
-import org.apache.hadoop.fs.{LocatedFileStatus, Path, RemoteIterator, FileUtil => fileUtil}
+import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path, RemoteIterator, FileUtil => fileUtil}
 import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
-
 
 /**
   * Handles input and output data for every data set or pipep line implementation.
@@ -30,6 +30,34 @@ object InputOutputDataHandler {
 
   /**
     *
+    * @param sparkContext Application Spark Context.
+    * @param feedbackFile Feedback file location.
+    * @return new RDD[String] with feedback or empty if file does not exists.
+    */
+  def getFeedbackRDD(sparkContext: SparkContext, feedbackFile: String): RDD[String] = {
+
+    val hadoopConfiguration = sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(hadoopConfiguration)
+
+    // We need to pass a default value "file" if fileName is "" to avoid error
+    // java.lang.IllegalArgumentException: Can not create a Path from an empty string
+    // when trying to create a new Path object with empty string.
+    val fileExists = fs.exists(new Path(if (feedbackFile == "") "file" else feedbackFile))
+
+    if (fileExists) {
+
+      // feedback file is a tab-separated file with a single header line. We need to remove the header
+      val lines = sparkContext.textFile(feedbackFile)
+      val header = lines.first()
+      lines.filter(line => line != header)
+
+    } else {
+      sparkContext.emptyRDD[String]
+    }
+  }
+
+  /**
+    *
     * @param sparkContext      Application SparkContext.
     * @param hdfsScoredConnect HDFS output folder. The location where results were saved; flow, dns or proxy.
     * @param analysis          Data type to analyze.
@@ -39,9 +67,9 @@ object InputOutputDataHandler {
     val hadoopConfiguration = sparkContext.hadoopConfiguration
     val fileSystem = org.apache.hadoop.fs.FileSystem.get(hadoopConfiguration)
 
-    val exists = fileSystem.exists(new org.apache.hadoop.fs.Path(hdfsScoredConnect))
+    val fileExists = fileSystem.exists(new org.apache.hadoop.fs.Path(hdfsScoredConnect))
 
-    if (exists) {
+    if (fileExists) {
       val srcDir = new Path(hdfsScoredConnect)
       val dstFile = new Path(hdfsScoredConnect + "/" + analysis + "_results.csv")
       fileUtil.copyMerge(fileSystem, srcDir, fileSystem, dstFile, false, hadoopConfiguration, "")


### PR DESCRIPTION
spot-ml component changes to align with CSV elimination and using HDFS instead of the local file system: 

- Implemented method to InputOutputDataHandler to read Feedback from HDFS and return RDD so every pipeline can then convert to DataFrame with the given schema.
- FlowFeedback.scala: changed the code to call method getFeedbackRDD; now validation if returned RDD.isEmpty instead of checking if the file exists.
- DNSFeedback.scala: same as flow.
- ProxyFeedback.scala: same as flow.
- ml_ops.sh: changed FEEDBACK_PATH to read from HPATH/feedback/ml_feedback.csv. Also deleted local path variables and lda results path; they are not needed anymore.

Issue fixed:
- FlowFeedback.scala: changed the code to create data frame, there was a missing conversion from string to integer in source and destination port.


